### PR TITLE
Remove compatibility check with 2006 library

### DIFF
--- a/lib/aws/s3.rb
+++ b/lib/aws/s3.rb
@@ -68,9 +68,6 @@ require_library_or_gem 'xmlsimple', 'xml-simple' unless defined? XmlSimple
 AWS::S3::Parsing.parser =
   begin
     require_library_or_gem 'xml/libxml'
-    # Older version of libxml aren't stable (bus error when requesting attributes that don't exist) so we
-    # have to use a version greater than '0.3.8.2'.
-    raise LoadError unless XML::Parser::VERSION > '0.3.8.2'
     $:.push(File.join(File.dirname(__FILE__), '..', '..', 'support', 'faster-xml-simple', 'lib'))
     require_library_or_gem 'faster_xml_simple' 
     FasterXmlSimple


### PR DESCRIPTION
`0.3.8.2` version of libxml was released in [November 2006](https://rubygems.org/gems/libxml-ruby/versions/0.3.8.2). Safe check is not required anymore and - even worse - it's not compatible with libxml 3.0.0.